### PR TITLE
Use bash for the scripts

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 set -eo pipefail
 
@@ -94,10 +94,10 @@ else
 
     SRC_FILE=dump.sql.gz
     DEST_FILE=${DB}_$(date +"%Y-%m-%dT%H:%M:%SZ").sql.gz
-    
+
     echo "Creating dump of ${DB} database from ${POSTGRES_HOST}..."
     pg_dump $POSTGRES_HOST_OPTS $DB | gzip > $SRC_FILE
-    
+
     if [ "${ENCRYPTION_PASSWORD}" != "**None**" ]; then
       echo "Encrypting ${SRC_FILE}"
       openssl enc -aes-256-cbc -in $SRC_FILE -out ${SRC_FILE}.enc -k $ENCRYPTION_PASSWORD

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 set -eo pipefail
 


### PR DESCRIPTION
`set -eo pipefail` won't work in the `dash` shell, but it does in `bash`. I think `bash` is available in this image, so lets just use it instead.