### PR TITLE
Use shell env in cron jobs

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,12 @@ if [ "${SCHEDULE}" = "**None**" ]; then
   /usr/src/backup.sh
 else
   echo "Found schedule, adding to crontab..."
-  echo -e "${SCHEDULE} /usr/src/backup.sh > /proc/1/fd/1 2> /proc/1/fd/2\n" > /usr/src/backup-crontab
+
+  # Dump environment variables into .env file
+  env > .env
+  sed -i '/^SCHEDULE=.*/d' .env # Remove SCHEDULE variable, causes problems because of the spaces
+
+  echo "SHELL=/bin/bash\nBASH_ENV=/usr/src/.env\n\n${SCHEDULE} /usr/src/backup.sh > /proc/1/fd/1 2> /proc/1/fd/2\n" >> /usr/src/backup-crontab
   crontab /usr/src/backup-crontab
   echo "Starting cron..."
   exec cron -f


### PR DESCRIPTION
This uses the shell environment variables in cron jobs. This was a confusing problem to figure out. It seems to be working now when I tested it. I also set bash as the shell, just to be sure that's what gets used.