### PR TITLE
Get DEPLOY_TO_CAPROVER from env

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,8 +58,6 @@ jobs:
     steps:
       - name: Deploy to Caprover
         uses: caprover/deploy-from-github@v1.1.2
-        env:
-          DEPLOY_TO_CAPROVER: ${{ secrets.DEPLOY_TO_CAPROVER }}
         if: env.DEPLOY_TO_CAPROVER
         with:
           server: ${{ secrets.CAPROVER_HOST }}


### PR DESCRIPTION
Putting it in secrets results in too much filtering out in the actions log. It shouldn't really matter having it be just an environment variable. Having it as a secret may have been unnecessary.